### PR TITLE
Bump squidfunk/mkdocs-material from 6.1.3 to 6.1.4 (#46)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:6.1.3
+FROM squidfunk/mkdocs-material:6.1.4
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh


### PR DESCRIPTION
Bumps squidfunk/mkdocs-material from 6.1.3 to 6.1.4.

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>